### PR TITLE
fix: docker warning

### DIFF
--- a/holesky/docker-compose.yml
+++ b/holesky/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   prometheus:
     image: ${PROMETHEUS_IMAGE}


### PR DESCRIPTION
logs:
```
WARN[0000] chainbase-dev/chainbase-avs-setup/holesky/docker-compose.yml: `version` is obsolete 
```